### PR TITLE
1.3.1 - Saving raw data without filesystem and saving data send by external tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.3.1 [2025-01-24]
+
+### Added
+- New endpoint to save raw data from questionnaire directly in MongoDB
+- New endpoint to save data send by external quality tools
+- New endpoint to save infos on a rundeck execution
+- Auto creation of indexes
+
+### Updated
+- spring boot 3.4.2
+- springdoc 2.8.3
+- pitest 1.17.4
+- bpm 1.0.5
+
 ## 1.3.0 [2024-12-16]
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fr.insee.genesis</groupId>
     <artifactId>genesis-api</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
     <name>genesis-api</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <pitest.version>1.17.4</pitest.version>
         <pitest.junit.version>1.2.1</pitest.junit.version>
         <jackson.version>2.18.2</jackson.version>
-        <bpm.version>1.0.4</bpm.version>
+        <bpm.version>1.0.5</bpm.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
### Added
- New endpoint to save raw data from questionnaire directly in MongoDB
- New endpoint to save data send by external quality tools
- New endpoint to save infos on a rundeck execution
- Auto creation of indexes

### Updated
- spring boot 3.4.2
- springdoc 2.8.3
- pitest 1.17.4
- bpm 1.0.5