### PR TITLE
Fix crash en cas de nom de dossier incorrect dans specs

### DIFF
--- a/src/main/java/fr/insee/genesis/configuration/LogRequestFilter.java
+++ b/src/main/java/fr/insee/genesis/configuration/LogRequestFilter.java
@@ -35,6 +35,7 @@ public class LogRequestFilter extends OncePerRequestFilter {
 		//	+ "Content-Type : {} \n "
 		//	+ "Headers : {} \n "
 			+ "Body : {} \n";
+	private static final int MAX_RESPONSE_SIZE = 10000;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -66,6 +67,7 @@ public class LogRequestFilter extends OncePerRequestFilter {
     }
 
 	private String getResponseBody(ContentCachingRequestWrapper req, ContentCachingResponseWrapper resp) {
+		if(req.getContentAsByteArray().length >= MAX_RESPONSE_SIZE) return "Swagger response too long";
 		if (req.getRequestURI().contains("swagger-ui") ||req.getRequestURI().contains("api-docs")) return "Hidden Swagger response";
 		return new String(resp.getContentAsByteArray(), StandardCharsets.UTF_8);
 	}

--- a/src/main/java/fr/insee/genesis/configuration/LogRequestFilter.java
+++ b/src/main/java/fr/insee/genesis/configuration/LogRequestFilter.java
@@ -26,16 +26,11 @@ public class LogRequestFilter extends OncePerRequestFilter {
 			 "CALL {} {} - "
 		//	+ "Content-Type :  {} \n "
 		//	+ "Headers : {} \n "
-			+ "Params : {} - "
-			+ "Body : {} \n ";
+			+ "Params : {}";
 	
 	private static final String RESPONSE_MESSAGE_FORMAT = 
 			 "END {} {}  - "
-			+ "Status :  {} - "
-		//	+ "Content-Type : {} \n "
-		//	+ "Headers : {} \n "
-			+ "Body : {} \n";
-	private static final int MAX_RESPONSE_SIZE = 10000;
+			+ "Status :  {} - ";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -46,11 +41,10 @@ public class LogRequestFilter extends OncePerRequestFilter {
         ContentCachingResponseWrapper resp = new ContentCachingResponseWrapper(response);
         
         log.info(REQUEST_MESSAGE_FORMAT, 
-        		req.getMethod(), req.getRequestURI(), 
+        		req.getMethod(), req.getRequestURI(),
         	//	req.getContentType(),
             //    new ServletServerHttpRequest(req).getHeaders(), //Headers
-                request.getQueryString(),//Params
-                new String(req.getContentAsByteArray(), StandardCharsets.UTF_8));//Body
+                request.getQueryString());//Params
 
 
         // Execution request chain
@@ -58,16 +52,14 @@ public class LogRequestFilter extends OncePerRequestFilter {
                
 
         log.info(RESPONSE_MESSAGE_FORMAT, 
-        		req.getMethod(), req.getRequestURI(), 
-        		resp.getStatus(),
-                getResponseBody(req, resp)); //Body
+        		req.getMethod(), req.getRequestURI(),
+        		resp.getStatus()); //Body
         
         // Finally remember to respond to the client with the cached data.
         resp.copyBodyToResponse();
     }
 
 	private String getResponseBody(ContentCachingRequestWrapper req, ContentCachingResponseWrapper resp) {
-		if(req.getContentAsByteArray().length >= MAX_RESPONSE_SIZE) return "Swagger response too long";
 		if (req.getRequestURI().contains("swagger-ui") ||req.getRequestURI().contains("api-docs")) return "Hidden Swagger response";
 		return new String(resp.getContentAsByteArray(), StandardCharsets.UTF_8);
 	}

--- a/src/main/java/fr/insee/genesis/controller/utils/ControllerUtils.java
+++ b/src/main/java/fr/insee/genesis/controller/utils/ControllerUtils.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -12,6 +13,7 @@ import fr.insee.genesis.exceptions.GenesisException;
 import fr.insee.genesis.infrastructure.utils.FileUtils;
 
 @Component
+@Slf4j
 public class ControllerUtils {
 
 	private final FileUtils fileUtils;
@@ -30,11 +32,17 @@ public class ControllerUtils {
 		}
 		List<Mode> modes = new ArrayList<>();
 		String specFolder = fileUtils.getSpecFolder(campaign);
-		List<String> specFolders = fileUtils.listFolders(specFolder);
-		if (specFolders.isEmpty()) {
+		List<String> modeSpecFolders = fileUtils.listFolders(specFolder);
+		if (modeSpecFolders.isEmpty()) {
 			throw new GenesisException(404, "No specification folder found " + specFolder);
 		}
-		specFolders.forEach(modeLabel -> modes.add(Mode.getEnumFromModeName(modeLabel)));
+		for(String modeSpecFolder : modeSpecFolders){
+			if(Mode.getEnumFromModeName(modeSpecFolder) == null) {
+				log.warn("There is an invalid mode folder name in spec folder : {}", modeSpecFolder);
+				continue;
+			}
+			modes.add(Mode.getEnumFromModeName(modeSpecFolder));
+		}
 		if (modes.contains(Mode.F2F) && modes.contains(Mode.TEL)) {
 			throw new GenesisException(409, "Cannot treat simultaneously TEL and FAF modes");
 		}


### PR DESCRIPTION
Exemple : 
2 dossiers dans specs FAF et F2F
F2F est le bon nom de dossier
Genesis va planter si on met modeSpecified à null dans responses/lunatic-xml/save-folder
Ce fix corrige ce cas de plantage et permet d'envoyer un warn dans la log en cas de nom de dossier de spec incorrect