### PR TITLE
refactor: reprocess service

### DIFF
--- a/src/main/java/fr/insee/genesis/controller/exception/ExceptionController.java
+++ b/src/main/java/fr/insee/genesis/controller/exception/ExceptionController.java
@@ -1,0 +1,44 @@
+package fr.insee.genesis.controller.exception;
+
+import fr.insee.genesis.exceptions.GenesisException;
+import fr.insee.genesis.exceptions.InvalidDateIntervalException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+/**
+ * This controller uses Spring's ControllerAdvice annotation to intercept exceptions.
+ * It implements the <a href="https://www.rfc-editor.org/rfc/rfc9457.html">RFC 9457</a> by returning
+ * Spring's <code>ProblemDetail</code> object.
+ */
+@ControllerAdvice
+@Slf4j
+public class ExceptionController {
+
+    // Note: No handler for uncaught Exception.class for now since it breaks soms tests.
+
+    @ExceptionHandler
+    public ProblemDetail handleGenericGenesisException(GenesisException genesisException) {
+        log.error("GenesisException: {}", genesisException.getMessage(), genesisException);
+        return ProblemDetail.forStatusAndDetail(
+                resolveHttpCode(genesisException.getStatus()),
+                genesisException.getMessage());
+    }
+
+    /** Returns the corresponding http status, or 500 if the given code does not match a http status. */
+    private static HttpStatus resolveHttpCode(int statusCode) {
+        HttpStatus httpStatus = HttpStatus.resolve(statusCode);
+        return httpStatus != null ? httpStatus : HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @ExceptionHandler(InvalidDateIntervalException.class)
+    public ProblemDetail handleInvalidDateIntervalException(InvalidDateIntervalException e) {
+        log.error("InvalidDateIntervalException: {}", e.getMessage());
+        return ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                e.getMessage());
+    }
+
+}

--- a/src/main/java/fr/insee/genesis/controller/rest/responses/RawResponseController.java
+++ b/src/main/java/fr/insee/genesis/controller/rest/responses/RawResponseController.java
@@ -14,8 +14,8 @@ import fr.insee.modelefiliere.RawResponseDto;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -37,22 +37,15 @@ import java.util.Set;
 
 @Slf4j
 @Controller
+@RequiredArgsConstructor
 public class RawResponseController {
 
     private static final String SUCCESS_MESSAGE = "Interrogation %s saved";
     private static final String INTERROGATION_ID = "interrogationId";
-    public static final String NB_DOCS_WITH_FORMATTED = "%d document(s) processed, including %d FORMATTED after data verification for collectionInstrumentId %s";
-    public static final String NB_DOCS = "%d document(s) processed for collectionInstrumentId %s";
+
     private final LunaticJsonRawDataApiPort lunaticJsonRawDataApiPort;
     private final RawResponseApiPort rawResponseApiPort;
     private final RawResponseInputRepository rawRepository;
-
-
-    public RawResponseController(LunaticJsonRawDataApiPort lunaticJsonRawDataApiPort, RawResponseApiPort rawResponseApiPort, RawResponseInputRepository rawRepository) {
-        this.lunaticJsonRawDataApiPort = lunaticJsonRawDataApiPort;
-        this.rawResponseApiPort = rawResponseApiPort;
-        this.rawRepository = rawRepository;
-    }
 
     @Operation(summary = "Save lunatic json data from one interrogation in Genesis Database")
     @PutMapping(path = "/responses/raw/lunatic-json/save")
@@ -113,10 +106,7 @@ public class RawResponseController {
         List<GenesisError> errors = new ArrayList<>();
         try {
             DataProcessResult result = rawResponseApiPort.processRawResponses(collectionInstrumentId, interrogationIdList, errors);
-            return result.formattedDataCount() == 0 ?
-                    ResponseEntity.ok(NB_DOCS.formatted(result.dataCount(), collectionInstrumentId))
-                    : ResponseEntity.ok(NB_DOCS_WITH_FORMATTED
-                    .formatted(result.dataCount(), result.formattedDataCount(), collectionInstrumentId));
+            return ResponseEntity.ok(result.message(collectionInstrumentId));
         } catch (GenesisException e) {
             return ResponseEntity.status(e.getStatus()).body(e.getMessage());
         }
@@ -135,58 +125,7 @@ public class RawResponseController {
         log.info("Try to process raw responses for collectionInstrumentId {}", collectionInstrumentId);
         try {
             DataProcessResult result = rawResponseApiPort.processRawResponses(collectionInstrumentId);
-            return result.formattedDataCount() == 0 ?
-                    ResponseEntity.ok(NB_DOCS.formatted(result.dataCount(), collectionInstrumentId))
-                    : ResponseEntity.ok(NB_DOCS_WITH_FORMATTED
-                    .formatted(result.dataCount(), result.formattedDataCount(), collectionInstrumentId));
-        } catch (GenesisException e) {
-            return ResponseEntity.status(e.getStatus()).body(e.getMessage());
-        }
-    }
-
-    @Operation(summary = "Reprocess raw data for processed data of a collection instrument")
-    @PostMapping(path = "/raw-responses/{collectionInstrumentId}/reprocess")
-    @PreAuthorize("hasRole('SCHEDULER')")
-    public ResponseEntity<String> reProcessRawResponsesByCollectionInstrumentId(
-            @Parameter(
-                    description = "Id of the collection instrument (old questionnaireId)",
-                    example = "ENQTEST2025X00"
-            )
-            @PathVariable("collectionInstrumentId") String collectionInstrumentId,
-            @RequestParam(value = "sinceDate", required = false)
-            @Parameter(description = "Extract since",
-                    schema = @Schema(type = "string", format = "date-time", example = "2026-01-01T00:00:00")
-            )
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime sinceDate,
-            @RequestParam(value = "endDate", required = false)
-            @Parameter(description = "Extract until",
-                    schema = @Schema(type = "string", format = "date-time", example = "2026-02-02T00:00:00")
-            )
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate
-    ) {
-        log.info(
-                "Try to reprocess raw responses for collectionInstrumentId {}, sinceDate={}, endDate={}",
-                collectionInstrumentId,
-                sinceDate,
-                endDate
-        );
-
-        try {
-            DataProcessResult result = rawResponseApiPort.reprocessRawResponses(
-                    collectionInstrumentId,
-                    sinceDate,
-                    endDate
-            );
-
-            return result.formattedDataCount() == 0
-                    ? ResponseEntity.ok(NB_DOCS.formatted(result.dataCount(), collectionInstrumentId))
-                    : ResponseEntity.ok(
-                    NB_DOCS_WITH_FORMATTED.formatted(
-                            result.dataCount(),
-                            result.formattedDataCount(),
-                            collectionInstrumentId
-                    )
-            );
+            return ResponseEntity.ok(result.message(collectionInstrumentId));
         } catch (GenesisException e) {
             return ResponseEntity.status(e.getStatus()).body(e.getMessage());
         }
@@ -266,54 +205,6 @@ public class RawResponseController {
                     ResponseEntity.ok("%d document(s) processed".formatted(result.dataCount()))
                     : ResponseEntity.ok("%d document(s) processed, including %d FORMATTED after data verification"
                     .formatted(result.dataCount(), result.formattedDataCount()));
-        } catch (GenesisException e) {
-            return ResponseEntity.status(e.getStatus()).body(e.getMessage());
-        }
-    }
-
-    @Operation(summary = "Reprocess raw data of a questionnaire (old raw model)")
-    @PostMapping(path = "/responses/raw/lunatic-json/{questionnaireId}/reprocess")
-    @PreAuthorize("hasRole('SCHEDULER')")
-    public ResponseEntity<String> reProcessJsonRawDataByQuestionnaireId(
-            @Parameter(
-                    description = "Id of the questionnaireId",
-                    example = "ENQTEST2025X00"
-            )
-            @PathVariable("questionnaireId") String questionnaireId,
-            @RequestParam(value = "sinceDate", required = false)
-            @Parameter(description = "Extract since",
-                    schema = @Schema(type = "string", format = "date-time", example = "2026-01-01T00:00:00")
-            )
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime sinceDate,
-            @RequestParam(value = "endDate", required = false)
-            @Parameter(description = "Extract until",
-                    schema = @Schema(type = "string", format = "date-time", example = "2026-02-02T00:00:00")
-            )
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate
-    ) {
-        log.info(
-                "Try to reprocess raw responses for questionnaireId {}, sinceDate={}, endDate={}",
-                questionnaireId,
-                sinceDate,
-                endDate
-        );
-
-        try {
-            DataProcessResult result = lunaticJsonRawDataApiPort.reprocessRawData(
-                    questionnaireId,
-                    sinceDate,
-                    endDate
-            );
-
-            return result.formattedDataCount() == 0
-                    ? ResponseEntity.ok(NB_DOCS.formatted(result.dataCount(), questionnaireId))
-                    : ResponseEntity.ok(
-                    NB_DOCS_WITH_FORMATTED.formatted(
-                            result.dataCount(),
-                            result.formattedDataCount(),
-                            questionnaireId
-                    )
-            );
         } catch (GenesisException e) {
             return ResponseEntity.status(e.getStatus()).body(e.getMessage());
         }

--- a/src/main/java/fr/insee/genesis/controller/rest/responses/RawResponseReprocessController.java
+++ b/src/main/java/fr/insee/genesis/controller/rest/responses/RawResponseReprocessController.java
@@ -1,0 +1,94 @@
+package fr.insee.genesis.controller.rest.responses;
+
+import fr.insee.genesis.domain.model.surveyunit.rawdata.DataProcessResult;
+import fr.insee.genesis.domain.model.surveyunit.rawdata.RawDataModelType;
+import fr.insee.genesis.domain.ports.api.ReprocessRawResponseApiPort;
+import fr.insee.genesis.exceptions.GenesisException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDateTime;
+
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class RawResponseReprocessController {
+
+    private final ReprocessRawResponseApiPort reprocessRawResponseApiPort;
+
+    @Operation(summary = "Reprocess raw response of a collection instrument.")
+    @PostMapping(path = "/raw-responses/{collectionInstrumentId}/reprocess")
+    @PreAuthorize("hasRole('SCHEDULER')")
+    public ResponseEntity<String> reProcessRawResponsesByCollectionInstrumentId(
+            @Parameter(
+                    description = "Id of the collection instrument (old questionnaireId)",
+                    example = "ENQTEST2025X00")
+            @PathVariable("collectionInstrumentId")
+            String collectionInstrumentId,
+
+            @Parameter(description = "Extract since",
+                    schema = @Schema(type = "string", format = "date-time", example = "2026-01-01T00:00:00"))
+            @RequestParam(value = "sinceDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+            LocalDateTime sinceDate,
+
+            @Parameter(description = "Extract until",
+                    schema = @Schema(type = "string", format = "date-time", example = "2026-02-02T00:00:00"))
+            @RequestParam(value = "endDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+            LocalDateTime endDate
+    ) throws GenesisException {
+
+        DataProcessResult result = reprocessRawResponseApiPort.reprocessRawResponses(
+                RawDataModelType.FILIERE,
+                collectionInstrumentId,
+                sinceDate,
+                endDate);
+
+        return ResponseEntity.ok(result.message(collectionInstrumentId));
+    }
+
+    @Operation(summary = "Reprocess Lunatic raw data for a questionnaire model. " +
+            "**Note**: Lunatic raw data is the legacy format of raw responses.")
+    @PostMapping(path = "/responses/raw/lunatic-json/{questionnaireId}/reprocess")
+    @PreAuthorize("hasRole('SCHEDULER')")
+    public ResponseEntity<String> reProcessJsonRawDataByQuestionnaireId(
+            @Parameter(
+                    description = "Questionnaire model id (old name for collection instrument id).",
+                    example = "ENQTEST2025X00")
+            @PathVariable("questionnaireId")
+            String collectionInstrumentId, // 'questionnaireId' is the legacy name for 'collectionInstrumentId'
+
+            @Parameter(description = "Extract since",
+                    schema = @Schema(type = "string", format = "date-time", example = "2026-01-01T00:00:00"))
+            @RequestParam(value = "sinceDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+            LocalDateTime sinceDate,
+
+            @Parameter(description = "Extract until",
+                    schema = @Schema(type = "string", format = "date-time", example = "2026-02-02T00:00:00"))
+            @RequestParam(value = "endDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+            LocalDateTime endDate
+    ) throws GenesisException {
+
+        DataProcessResult result = reprocessRawResponseApiPort.reprocessRawResponses(
+                RawDataModelType.LEGACY,
+                collectionInstrumentId,
+                sinceDate,
+                endDate);
+
+        return ResponseEntity.ok(result.message(collectionInstrumentId));
+    }
+
+}

--- a/src/main/java/fr/insee/genesis/domain/model/surveyunit/rawdata/DataProcessResult.java
+++ b/src/main/java/fr/insee/genesis/domain/model/surveyunit/rawdata/DataProcessResult.java
@@ -4,5 +4,31 @@ import fr.insee.genesis.exceptions.GenesisError;
 
 import java.util.List;
 
-public record DataProcessResult(int dataCount, int formattedDataCount, List<GenesisError> errors) {
+public record DataProcessResult(
+        int dataCount,
+        int formattedDataCount,
+        List<GenesisError> errors) {
+
+    public String message(String collectionInstrumentId) {
+        return String.format("%s%s%s.",
+                interrogationCountMessage(dataCount),
+                formattedCountMessage(formattedDataCount),
+                collectionIdMessage(collectionInstrumentId));
+    }
+
+    private static String interrogationCountMessage(int processedInterrogationsCount) {
+        boolean plural = processedInterrogationsCount > 1;
+        return "%d interrogation%s processed".formatted(processedInterrogationsCount,  plural ? "s" : "");
+    }
+
+    private static String collectionIdMessage(String collectionInstrumentId) {
+        return " for collectionInstrumentId '%s'".formatted(collectionInstrumentId);
+    }
+
+    private static String formattedCountMessage(int formattedCount) {
+        if (formattedCount == 0)
+            return "";
+        return " (including %d FORMATTED after data verification)".formatted(formattedCount);
+    }
+
 }

--- a/src/main/java/fr/insee/genesis/domain/model/surveyunit/rawdata/RawDataModelType.java
+++ b/src/main/java/fr/insee/genesis/domain/model/surveyunit/rawdata/RawDataModelType.java
@@ -1,5 +1,20 @@
 package fr.insee.genesis.domain.model.surveyunit.rawdata;
 
+/** Format of raw data to be imported into the data storage. */
 public enum RawDataModelType {
-    DEFAULT, FILIERE
+
+    /** Legacy format of raw data ('Lunatic'). */
+    LEGACY,
+
+    /** 'Filière' raw response model. */
+    FILIERE;
+
+    @Override
+    public String toString() {
+        return switch (this) {
+            case LEGACY -> "LEGACY (Lunatic)";
+            case FILIERE -> "FILIERE raw responses";
+        };
+    }
+
 }

--- a/src/main/java/fr/insee/genesis/domain/ports/api/LunaticJsonRawDataApiPort.java
+++ b/src/main/java/fr/insee/genesis/domain/ports/api/LunaticJsonRawDataApiPort.java
@@ -21,13 +21,6 @@ public interface LunaticJsonRawDataApiPort {
 
     void save(LunaticJsonRawDataModel rawData);
     List<LunaticJsonRawDataModel> getRawDataByQuestionnaireId(String questionnaireId, Mode mode, List<String> interrogationIdList);
-
-    DataProcessResult reprocessRawData(
-            String questionnaireId,
-            LocalDateTime sinceDate,
-            LocalDateTime endDate
-    ) throws GenesisException;
-
     List<SurveyUnitModel> convertRawData(List<LunaticJsonRawDataModel> rawData, VariablesMap variablesMap);
 
     List<LunaticJsonRawDataUnprocessedDto> getUnprocessedDataIds();

--- a/src/main/java/fr/insee/genesis/domain/ports/api/RawResponseApiPort.java
+++ b/src/main/java/fr/insee/genesis/domain/ports/api/RawResponseApiPort.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -21,12 +20,6 @@ public interface RawResponseApiPort {
     List<RawResponseModel> getRawResponsesByInterrogationID(String interrogationId);
     DataProcessResult processRawResponses(String collectionInstrumentId, List<String> interrogationIdList, List<GenesisError> errors) throws GenesisException;
     DataProcessResult processRawResponses(String collectionInstrumentId) throws GenesisException;
-
-    DataProcessResult reprocessRawResponses(
-            String collectionInstrumentId,
-            LocalDateTime sinceDate,
-            LocalDateTime endDate
-    ) throws GenesisException;
 
     List<SurveyUnitModel> convertRawResponse(List<RawResponseModel> rawResponses, VariablesMap variablesMap);
     List<String> getUnprocessedCollectionInstrumentIds();

--- a/src/main/java/fr/insee/genesis/domain/ports/api/ReprocessRawResponseApiPort.java
+++ b/src/main/java/fr/insee/genesis/domain/ports/api/ReprocessRawResponseApiPort.java
@@ -1,0 +1,26 @@
+package fr.insee.genesis.domain.ports.api;
+
+import fr.insee.genesis.domain.model.surveyunit.rawdata.DataProcessResult;
+import fr.insee.genesis.domain.model.surveyunit.rawdata.RawDataModelType;
+import fr.insee.genesis.exceptions.GenesisException;
+
+import java.time.LocalDateTime;
+
+public interface ReprocessRawResponseApiPort {
+
+    /**
+     * Reprocesses raw data of the collection that correspond to the given identifier.
+     * An optional date interval can be given to reprocess a subset of the collection.
+     * @param rawDataModelType {@link RawDataModelType}
+     * @param collectionInstrumentId Collection instrument identifier.
+     * @param sinceDate Start of the date interval.
+     * @param endDate End of the date interval.
+     * @return Data processing result record.
+     * @see DataProcessResult
+     */
+    DataProcessResult reprocessRawResponses(
+            RawDataModelType rawDataModelType,
+            String collectionInstrumentId, LocalDateTime sinceDate, LocalDateTime endDate)
+            throws GenesisException;
+
+}

--- a/src/main/java/fr/insee/genesis/domain/ports/api/SurveyUnitApiPort.java
+++ b/src/main/java/fr/insee/genesis/domain/ports/api/SurveyUnitApiPort.java
@@ -1,11 +1,7 @@
 package fr.insee.genesis.domain.ports.api;
 
 import fr.insee.bpm.metadata.model.VariablesMap;
-import fr.insee.genesis.controller.dto.CampaignWithQuestionnaire;
-import fr.insee.genesis.controller.dto.QuestionnaireWithCampaign;
-import fr.insee.genesis.controller.dto.SurveyUnitDto;
-import fr.insee.genesis.controller.dto.SurveyUnitInputDto;
-import fr.insee.genesis.controller.dto.SurveyUnitSimplifiedDto;
+import fr.insee.genesis.controller.dto.*;
 import fr.insee.genesis.domain.model.surveyunit.InterrogationId;
 import fr.insee.genesis.domain.model.surveyunit.Mode;
 import fr.insee.genesis.domain.model.surveyunit.SurveyUnitModel;
@@ -72,11 +68,6 @@ public interface SurveyUnitApiPort {
     //========= OPTIMISATIONS PERFS (END) ==========
 
     Long deleteByCollectionInstrumentId(String collectionInstrumentId);
-
-    Long deleteByCollectionInstrumentIdAndInterrogationIds(
-            String collectionInstrumentId,
-            Set<String> interrogationIds
-    );
 
     Long deleteByQuestionnaireIdAndInterrogationIds(
             String questionnaireId,

--- a/src/main/java/fr/insee/genesis/domain/ports/spi/LunaticJsonRawDataPersistencePort.java
+++ b/src/main/java/fr/insee/genesis/domain/ports/spi/LunaticJsonRawDataPersistencePort.java
@@ -20,8 +20,6 @@ public interface LunaticJsonRawDataPersistencePort {
     List<LunaticJsonRawDataModel> getAllUnprocessedData();
     void updateProcessDates(String campaignId, Set<String> interrogationIds);
 
-    void resetProcessDates(String questionnaireId, Set<String> interrogationIds);
-
     Set<String> findDistinctQuestionnaireIds();
     Set<String> findDistinctQuestionnaireIdsByNullProcessDate();
     Set<Mode> findModesByQuestionnaire(String questionnaireId);
@@ -34,11 +32,4 @@ public interface LunaticJsonRawDataPersistencePort {
     boolean existsByInterrogationId(String interrogationId);
     long countDistinctInterrogationIdsByQuestionnaireId(String questionnaireId);
 
-    Set<String> findProcessedInterrogationIdsByQuestionnaireId(String questionnaireId);
-
-    Set<String> findProcessedInterrogationIdsByQuestionnaireIdAndRecordDateBetween(
-            String questionnaireId,
-            LocalDateTime sinceDate,
-            LocalDateTime endDate
-    );
 }

--- a/src/main/java/fr/insee/genesis/domain/ports/spi/RawResponsePersistencePort.java
+++ b/src/main/java/fr/insee/genesis/domain/ports/spi/RawResponsePersistencePort.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -24,13 +23,6 @@ public interface RawResponsePersistencePort {
     Set<String> findDistinctCollectionInstrumentIds();
     long countDistinctInterrogationIdsByCollectionInstrumentId(String collectionInstrumentId);
     Page<RawResponseModel> findByCollectionInstrumentId(String collectionInstrumentId, Pageable pageable);
-    Set<String> findProcessedInterrogationIdsByCollectionInstrumentId(String collectionInstrumentId);
-    Set<String> findProcessedInterrogationIdsByCollectionInstrumentIdAndRecordDateBetween(
-            String collectionInstrumentId,
-            LocalDateTime sinceDate,
-            LocalDateTime endDate
-    );
-
-    void resetProcessDates(String collectionInstrumentId, Set<String> interrogationIds);
     boolean existsByInterrogationId(String interrogationId);
+
 }

--- a/src/main/java/fr/insee/genesis/domain/ports/spi/RawResponseReprocessPersistencePort.java
+++ b/src/main/java/fr/insee/genesis/domain/ports/spi/RawResponseReprocessPersistencePort.java
@@ -1,0 +1,16 @@
+package fr.insee.genesis.domain.ports.spi;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+public interface RawResponseReprocessPersistencePort {
+
+    Set<String> findProcessedInterrogationIdsByCollectionInstrumentId(
+            String collectionInstrumentId);
+
+    Set<String> findProcessedInterrogationIdsByCollectionInstrumentIdAndRecordDateBetween(
+            String collectionInstrumentId, LocalDateTime sinceDate, LocalDateTime endDate);
+
+    void resetProcessDates(String collectionInstrumentId, Set<String> interrogationIds);
+
+}

--- a/src/main/java/fr/insee/genesis/domain/ports/spi/RawResponseReprocessPersistenceRouter.java
+++ b/src/main/java/fr/insee/genesis/domain/ports/spi/RawResponseReprocessPersistenceRouter.java
@@ -1,0 +1,9 @@
+package fr.insee.genesis.domain.ports.spi;
+
+import fr.insee.genesis.domain.model.surveyunit.rawdata.RawDataModelType;
+
+public interface RawResponseReprocessPersistenceRouter {
+
+    RawResponseReprocessPersistencePort resolve(RawDataModelType rawDataModelType);
+
+}

--- a/src/main/java/fr/insee/genesis/domain/service/rawdata/LunaticJsonRawDataService.java
+++ b/src/main/java/fr/insee/genesis/domain/service/rawdata/LunaticJsonRawDataService.java
@@ -263,56 +263,6 @@ public class LunaticJsonRawDataService implements LunaticJsonRawDataApiPort {
 
 
     @Override
-    public DataProcessResult reprocessRawData(
-            String questionnaireId,
-            LocalDateTime sinceDate,
-            LocalDateTime endDate
-    ) throws GenesisException {
-
-        log.info(
-                "Reprocessing raw responses for questionnaireId={}, sinceDate={}, endDate={}",
-                questionnaireId,
-                sinceDate,
-                endDate
-        );
-
-        if (sinceDate == null && endDate != null) {
-            throw new GenesisException(400, "endDate cannot be provided without sinceDate");
-        }
-
-        if (sinceDate != null && endDate != null && endDate.isBefore(sinceDate)) {
-            throw new GenesisException(400, "endDate must be after or equal to sinceDate");
-        }
-
-        Set<String> interrogationIds;
-
-        if (sinceDate == null) {
-            interrogationIds =
-                    lunaticJsonRawDataPersistencePort.findProcessedInterrogationIdsByQuestionnaireId(questionnaireId);
-        } else {
-            LocalDateTime effectiveEndDate = endDate != null ? endDate : LocalDateTime.now();
-
-            interrogationIds =
-                    lunaticJsonRawDataPersistencePort.findProcessedInterrogationIdsByQuestionnaireIdAndRecordDateBetween(
-                            questionnaireId,
-                            sinceDate,
-                            effectiveEndDate
-                    );
-        }
-
-        if (interrogationIds.isEmpty()) {
-            return new DataProcessResult(0, 0, new ArrayList<>());
-        }
-
-        surveyUnitService.deleteByQuestionnaireIdAndInterrogationIds(questionnaireId, interrogationIds);
-        lunaticJsonRawDataPersistencePort.resetProcessDates(questionnaireId, interrogationIds);
-
-        return processRawData(questionnaireId,  new ArrayList<>(interrogationIds),
-                new ArrayList<>());
-    }
-
-
-    @Override
     public List<SurveyUnitModel> convertRawData(List<LunaticJsonRawDataModel> rawDataList, VariablesMap variablesMap) {
         //Convert to genesis model
         List<SurveyUnitModel> surveyUnitModels = new ArrayList<>();
@@ -371,7 +321,7 @@ public class LunaticJsonRawDataService implements LunaticJsonRawDataApiPort {
     private static RawDataModelType getRawDataModelType(LunaticJsonRawDataModel rawData) {
         return rawData.data().containsKey("data") ?
                 RawDataModelType.FILIERE :
-                RawDataModelType.DEFAULT;
+                RawDataModelType.LEGACY;
     }
 
     private static LocalDateTime getValidationDate(LunaticJsonRawDataModel rawData) {

--- a/src/main/java/fr/insee/genesis/domain/service/rawdata/RawResponseService.java
+++ b/src/main/java/fr/insee/genesis/domain/service/rawdata/RawResponseService.java
@@ -37,12 +37,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static fr.insee.genesis.domain.service.rawdata.LunaticJsonRawDataService.getValueString;
@@ -194,55 +189,6 @@ public class  RawResponseService implements RawResponseApiPort {
             }
         }
         return new DataProcessResult(dataCount, formattedDataCount, errors);
-    }
-
-    @Override
-    public DataProcessResult reprocessRawResponses(
-            String collectionInstrumentId,
-            LocalDateTime sinceDate,
-            LocalDateTime endDate
-    ) throws GenesisException {
-
-        log.info(
-                "Reprocessing raw responses for collectionInstrumentId={}, sinceDate={}, endDate={}",
-                collectionInstrumentId,
-                sinceDate,
-                endDate
-        );
-
-        if (sinceDate == null && endDate != null) {
-            throw new GenesisException(400, "endDate cannot be provided without sinceDate");
-        }
-
-        if (sinceDate != null && endDate != null && endDate.isBefore(sinceDate)) {
-            throw new GenesisException(400, "endDate must be after or equal to sinceDate");
-        }
-
-        Set<String> interrogationIds;
-
-        if (sinceDate == null) {
-            interrogationIds =
-                    rawResponsePersistencePort.findProcessedInterrogationIdsByCollectionInstrumentId(collectionInstrumentId);
-        } else {
-            LocalDateTime effectiveEndDate = endDate != null ? endDate : LocalDateTime.now();
-
-            interrogationIds =
-                    rawResponsePersistencePort.findProcessedInterrogationIdsByCollectionInstrumentIdAndRecordDateBetween(
-                            collectionInstrumentId,
-                            sinceDate,
-                            effectiveEndDate
-                    );
-        }
-
-        if (interrogationIds.isEmpty()) {
-            return new DataProcessResult(0, 0, new ArrayList<>());
-        }
-
-        surveyUnitService.deleteByCollectionInstrumentIdAndInterrogationIds(collectionInstrumentId, interrogationIds);
-        rawResponsePersistencePort.resetProcessDates(collectionInstrumentId, interrogationIds);
-
-        return processRawResponses(collectionInstrumentId,  new ArrayList<>(interrogationIds),
-                new ArrayList<>());
     }
 
 

--- a/src/main/java/fr/insee/genesis/domain/service/rawdata/ReprocessRawResponseService.java
+++ b/src/main/java/fr/insee/genesis/domain/service/rawdata/ReprocessRawResponseService.java
@@ -1,0 +1,118 @@
+package fr.insee.genesis.domain.service.rawdata;
+
+import fr.insee.genesis.domain.model.surveyunit.rawdata.DataProcessResult;
+import fr.insee.genesis.domain.model.surveyunit.rawdata.RawDataModelType;
+import fr.insee.genesis.domain.ports.api.LunaticJsonRawDataApiPort;
+import fr.insee.genesis.domain.ports.api.RawResponseApiPort;
+import fr.insee.genesis.domain.ports.api.ReprocessRawResponseApiPort;
+import fr.insee.genesis.domain.ports.spi.RawResponseReprocessPersistencePort;
+import fr.insee.genesis.domain.ports.spi.RawResponseReprocessPersistenceRouter;
+import fr.insee.genesis.domain.ports.spi.SurveyUnitPersistencePort;
+import fr.insee.genesis.exceptions.GenesisException;
+import fr.insee.genesis.exceptions.InvalidDateIntervalException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReprocessRawResponseService implements ReprocessRawResponseApiPort {
+
+    private final SurveyUnitPersistencePort surveyUnitPersistence;
+
+    private final RawResponseApiPort rawResponseService;
+    private final LunaticJsonRawDataApiPort lunaticJsonRawDataService;
+    // Polymorphism for the raw data services would cause too much refactor.
+
+    private final RawResponseReprocessPersistenceRouter rawResponseReprocessPersistenceRouter;
+    private RawResponseReprocessPersistencePort rawResponseReprocessPersistencePort;
+
+    private enum InputFilterType {
+        COLLECTION_ID,
+        COLLECTION_ID_AND_DATE
+    }
+
+    @Override
+    public DataProcessResult reprocessRawResponses(
+            @NonNull RawDataModelType rawDataModelType,
+            @NonNull String collectionInstrumentId,
+            LocalDateTime sinceDate,
+            LocalDateTime endDate) throws GenesisException {
+
+        log.info("Start reprocess {} data for collectionInstrumentId={}, sinceDate={}, endDate={}",
+                rawDataModelType, collectionInstrumentId, sinceDate, endDate);
+
+        InputFilterType inputFilterType = validateInputs(sinceDate, endDate);
+
+        rawResponseReprocessPersistencePort = rawResponseReprocessPersistenceRouter.resolve(rawDataModelType);
+
+        Set<String> interrogationIds = switch (inputFilterType) {
+            case COLLECTION_ID ->
+                    rawResponseReprocessPersistencePort
+                            .findProcessedInterrogationIdsByCollectionInstrumentId(
+                                    collectionInstrumentId);
+            case COLLECTION_ID_AND_DATE ->
+                    rawResponseReprocessPersistencePort
+                            .findProcessedInterrogationIdsByCollectionInstrumentIdAndRecordDateBetween(
+                                    collectionInstrumentId,
+                                    sinceDate,
+                                    effectiveEndDate(endDate));
+        };
+
+        return reprocessInterrogations(rawDataModelType, collectionInstrumentId, interrogationIds);
+    }
+
+    private static InputFilterType validateInputs(LocalDateTime sinceDate, LocalDateTime endDate) {
+        if (bothDatesAreNull(sinceDate, endDate)) {
+            return InputFilterType.COLLECTION_ID;
+        }
+        if (sinceDate == null) {
+            throw new InvalidDateIntervalException("'endDate' cannot be provided without 'sinceDate'.");
+        }
+        if (endIsBeforeSince(sinceDate, endDate)) {
+            throw new InvalidDateIntervalException("'endDate' value cannot be before 'sinceDate'.");
+        }
+        return InputFilterType.COLLECTION_ID_AND_DATE;
+    }
+
+    private static boolean endIsBeforeSince(LocalDateTime sinceDate, LocalDateTime endDate) {
+        return endDate != null && endDate.isBefore(sinceDate);
+    }
+
+    private static boolean bothDatesAreNull(LocalDateTime sinceDate, LocalDateTime endDate) {
+        return sinceDate == null && endDate == null;
+    }
+
+    private static LocalDateTime effectiveEndDate(LocalDateTime endDate) {
+        if (endDate != null)
+            return endDate;
+        var now = LocalDateTime.now();
+        log.info("Effective end date: {}", now);
+        return now;
+    }
+
+    private DataProcessResult reprocessInterrogations(
+            RawDataModelType rawDataModelType, String collectionInstrumentId, Set<String> interrogationIds)
+            throws GenesisException {
+        if (interrogationIds.isEmpty()) {
+            return new DataProcessResult(0, 0, new ArrayList<>());
+        }
+
+        surveyUnitPersistence.deleteByCollectionInstrumentIdAndInterrogationIds(collectionInstrumentId, interrogationIds);
+        rawResponseReprocessPersistencePort.resetProcessDates(collectionInstrumentId, interrogationIds);
+
+        return switch (rawDataModelType) {
+            case FILIERE -> rawResponseService.processRawResponses(
+                    collectionInstrumentId, new ArrayList<>(interrogationIds), new ArrayList<>());
+            case LEGACY -> lunaticJsonRawDataService.processRawData(
+                    collectionInstrumentId, new ArrayList<>(interrogationIds), new ArrayList<>());
+        };
+    }
+
+}

--- a/src/main/java/fr/insee/genesis/domain/service/surveyunit/SurveyUnitService.java
+++ b/src/main/java/fr/insee/genesis/domain/service/surveyunit/SurveyUnitService.java
@@ -2,20 +2,8 @@ package fr.insee.genesis.domain.service.surveyunit;
 
 import fr.insee.bpm.metadata.model.VariableType;
 import fr.insee.bpm.metadata.model.VariablesMap;
-import fr.insee.genesis.controller.dto.CampaignWithQuestionnaire;
-import fr.insee.genesis.controller.dto.QuestionnaireWithCampaign;
-import fr.insee.genesis.controller.dto.SurveyUnitDto;
-import fr.insee.genesis.controller.dto.SurveyUnitInputDto;
-import fr.insee.genesis.controller.dto.SurveyUnitSimplifiedDto;
-import fr.insee.genesis.controller.dto.VariableDto;
-import fr.insee.genesis.controller.dto.VariableInputDto;
-import fr.insee.genesis.controller.dto.VariableStateDto;
-import fr.insee.genesis.domain.model.surveyunit.DataState;
-import fr.insee.genesis.domain.model.surveyunit.InterrogationId;
-import fr.insee.genesis.domain.model.surveyunit.Mode;
-import fr.insee.genesis.domain.model.surveyunit.SurveyUnitModel;
-import fr.insee.genesis.domain.model.surveyunit.VarIdScopeTuple;
-import fr.insee.genesis.domain.model.surveyunit.VariableModel;
+import fr.insee.genesis.controller.dto.*;
+import fr.insee.genesis.domain.model.surveyunit.*;
 import fr.insee.genesis.domain.ports.api.SurveyUnitApiPort;
 import fr.insee.genesis.domain.ports.spi.SurveyUnitPersistencePort;
 import fr.insee.genesis.domain.service.metadata.QuestionnaireMetadataService;
@@ -30,13 +18,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -494,14 +476,6 @@ public class SurveyUnitService implements SurveyUnitApiPort {
     @Override
     public Long deleteByCollectionInstrumentId(String collectionInstrumentId) {
         return surveyUnitPersistencePort.deleteByCollectionInstrumentId(collectionInstrumentId);
-    }
-
-    @Override
-    public Long deleteByCollectionInstrumentIdAndInterrogationIds(
-            String collectionInstrumentId,
-            Set<String> interrogationIds
-    ) {
-        return surveyUnitPersistencePort.deleteByCollectionInstrumentIdAndInterrogationIds(collectionInstrumentId, interrogationIds);
     }
 
     @Override

--- a/src/main/java/fr/insee/genesis/exceptions/InvalidDateIntervalException.java
+++ b/src/main/java/fr/insee/genesis/exceptions/InvalidDateIntervalException.java
@@ -1,0 +1,9 @@
+package fr.insee.genesis.exceptions;
+
+public class InvalidDateIntervalException extends RuntimeException {
+
+    public InvalidDateIntervalException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/fr/insee/genesis/infrastructure/adapter/LunaticJsonRawDataMongoAdapter.java
+++ b/src/main/java/fr/insee/genesis/infrastructure/adapter/LunaticJsonRawDataMongoAdapter.java
@@ -30,6 +30,7 @@ import java.util.Set;
 @Service
 @Qualifier("lunaticJsonMongoAdapter")
 public class LunaticJsonRawDataMongoAdapter implements LunaticJsonRawDataPersistencePort {
+
     private final LunaticJsonMongoDBRepository repository;
     private final MongoTemplate mongoTemplate;
 
@@ -88,18 +89,6 @@ public class LunaticJsonRawDataMongoAdapter implements LunaticJsonRawDataPersist
     }
 
     @Override
-    public void resetProcessDates(String questionnaireId, Set<String> interrogationIds) {
-        mongoTemplate.updateMulti(
-                Query.query(
-                        Criteria.where("questionnaireId").is(questionnaireId)
-                                .and("interrogationId").in(interrogationIds)
-                ),
-                new Update().unset("processDate"),
-                Constants.MONGODB_LUNATIC_RAWDATA_COLLECTION_NAME
-        );
-    }
-
-    @Override
     public Set<String> findDistinctQuestionnaireIds() {
         List<String> ids = mongoTemplate.query(LunaticJsonRawDataDocument.class)
                     .distinct("questionnaireId")
@@ -153,27 +142,5 @@ public class LunaticJsonRawDataMongoAdapter implements LunaticJsonRawDataPersist
         Long count = repository.countDistinctInterrogationIdsByQuestionnaireId(questionnaireId);
         return count != null ? count : 0;
     }
-
-    @Override
-    public Set<String> findProcessedInterrogationIdsByQuestionnaireId(String questionnaireId) {
-        return new HashSet<>(repository.findProcessedInterrogationIdsByQuestionnaireId(questionnaireId));
-    }
-
-    @Override
-    public Set<String> findProcessedInterrogationIdsByQuestionnaireIdAndRecordDateBetween(
-            String questionnaireId,
-            LocalDateTime sinceDate,
-            LocalDateTime endDate
-    ) {
-        return new HashSet<>(
-                repository.findProcessedInterrogationIdsByQuestionnaireIdAndRecordDateBetween(
-                        questionnaireId,
-                        sinceDate,
-                        endDate
-                )
-        );
-    }
-
-
 
 }

--- a/src/main/java/fr/insee/genesis/infrastructure/adapter/LunaticJsonReprocessMongoAdapter.java
+++ b/src/main/java/fr/insee/genesis/infrastructure/adapter/LunaticJsonReprocessMongoAdapter.java
@@ -1,0 +1,60 @@
+package fr.insee.genesis.infrastructure.adapter;
+
+import fr.insee.genesis.Constants;
+import fr.insee.genesis.domain.ports.spi.RawResponseReprocessPersistencePort;
+import fr.insee.genesis.infrastructure.repository.LunaticJsonMongoDBRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+@AllArgsConstructor
+@Qualifier("lunaticJsonReprocessMongoAdapter")
+public class LunaticJsonReprocessMongoAdapter implements RawResponseReprocessPersistencePort {
+
+    private final LunaticJsonMongoDBRepository repository;
+    private final MongoTemplate mongoTemplate;
+
+    /**
+     * @param questionnaireId Legacy name for 'collectionInstrumentId'.
+     */
+    @Override
+    public Set<String> findProcessedInterrogationIdsByCollectionInstrumentId(String questionnaireId) {
+        return new HashSet<>(repository.findProcessedInterrogationIdsByQuestionnaireId(questionnaireId));
+    }
+
+    /**
+     * @param questionnaireId Legacy name for 'collectionInstrumentId'.
+     */
+    @Override
+    public Set<String> findProcessedInterrogationIdsByCollectionInstrumentIdAndRecordDateBetween(
+            String questionnaireId, LocalDateTime sinceDate, LocalDateTime endDate) {
+        return new HashSet<>(
+                repository.findProcessedInterrogationIdsByQuestionnaireIdAndRecordDateBetween(
+                        questionnaireId, sinceDate, endDate));
+    }
+
+    /**
+     * @param questionnaireId Legacy name for 'collectionInstrumentId'.
+     */
+    @Override
+    public void resetProcessDates(String questionnaireId, Set<String> interrogationIds) {
+        mongoTemplate.updateMulti(
+                Query.query(
+                        Criteria.where("questionnaireId").is(questionnaireId)
+                                .and("interrogationId").in(interrogationIds)
+                ),
+                new Update().unset("processDate"),
+                Constants.MONGODB_LUNATIC_RAWDATA_COLLECTION_NAME
+        );
+    }
+
+}

--- a/src/main/java/fr/insee/genesis/infrastructure/adapter/RawResponseMongoAdapter.java
+++ b/src/main/java/fr/insee/genesis/infrastructure/adapter/RawResponseMongoAdapter.java
@@ -106,38 +106,6 @@ public class RawResponseMongoAdapter implements RawResponsePersistencePort {
     }
 
     @Override
-    public Set<String> findProcessedInterrogationIdsByCollectionInstrumentId(String collectionInstrumentId) {
-        return new HashSet<>(repository.findProcessedInterrogationIdsByCollectionInstrumentId(collectionInstrumentId));
-    }
-
-    @Override
-    public Set<String> findProcessedInterrogationIdsByCollectionInstrumentIdAndRecordDateBetween(
-            String collectionInstrumentId,
-            LocalDateTime sinceDate,
-            LocalDateTime endDate
-    ) {
-        return new HashSet<>(
-                repository.findProcessedInterrogationIdsByCollectionInstrumentIdAndRecordDateBetween(
-                        collectionInstrumentId,
-                        sinceDate,
-                        endDate
-                )
-        );
-    }
-
-    @Override
-    public void resetProcessDates(String collectionInstrumentId, Set<String> interrogationIds) {
-        mongoTemplate.updateMulti(
-                Query.query(
-                        Criteria.where("collectionInstrumentId").is(collectionInstrumentId)
-                                .and("interrogationId").in(interrogationIds)
-                ),
-                new Update().unset("processDate"),
-                Constants.MONGODB_RAW_RESPONSES_COLLECTION_NAME
-        );
-    }
-
-    @Override
     public boolean existsByInterrogationId(String interrogationId) {
         return repository.existsByInterrogationId(interrogationId);
     }

--- a/src/main/java/fr/insee/genesis/infrastructure/adapter/RawResponseReprocessMongoAdapter.java
+++ b/src/main/java/fr/insee/genesis/infrastructure/adapter/RawResponseReprocessMongoAdapter.java
@@ -1,0 +1,51 @@
+package fr.insee.genesis.infrastructure.adapter;
+
+import fr.insee.genesis.Constants;
+import fr.insee.genesis.domain.ports.spi.RawResponseReprocessPersistencePort;
+import fr.insee.genesis.infrastructure.repository.RawResponseRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Qualifier("rawResponseMongoAdapter")
+public class RawResponseReprocessMongoAdapter implements RawResponseReprocessPersistencePort {
+
+    private final RawResponseRepository repository;
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public Set<String> findProcessedInterrogationIdsByCollectionInstrumentId(String collectionInstrumentId) {
+        return new HashSet<>(repository.findProcessedInterrogationIdsByCollectionInstrumentId(collectionInstrumentId));
+    }
+
+    @Override
+    public Set<String> findProcessedInterrogationIdsByCollectionInstrumentIdAndRecordDateBetween(
+            String collectionInstrumentId, LocalDateTime sinceDate, LocalDateTime endDate) {
+        return new HashSet<>(
+                repository.findProcessedInterrogationIdsByCollectionInstrumentIdAndRecordDateBetween(
+                        collectionInstrumentId, sinceDate, endDate));
+    }
+
+    @Override
+    public void resetProcessDates(String collectionInstrumentId, Set<String> interrogationIds) {
+        mongoTemplate.updateMulti(
+                Query.query(
+                        Criteria.where("collectionInstrumentId").is(collectionInstrumentId)
+                                .and("interrogationId").in(interrogationIds)
+                ),
+                new Update().unset("processDate"),
+                Constants.MONGODB_RAW_RESPONSES_COLLECTION_NAME
+        );
+    }
+
+}

--- a/src/main/java/fr/insee/genesis/infrastructure/adapter/RawResponseReprocessMongoRouter.java
+++ b/src/main/java/fr/insee/genesis/infrastructure/adapter/RawResponseReprocessMongoRouter.java
@@ -1,0 +1,24 @@
+package fr.insee.genesis.infrastructure.adapter;
+
+import fr.insee.genesis.domain.model.surveyunit.rawdata.RawDataModelType;
+import fr.insee.genesis.domain.ports.spi.RawResponseReprocessPersistencePort;
+import fr.insee.genesis.domain.ports.spi.RawResponseReprocessPersistenceRouter;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class RawResponseReprocessMongoRouter implements RawResponseReprocessPersistenceRouter {
+
+    private final RawResponseReprocessMongoAdapter rawResponseReprocessMongoAdapter;
+    private final LunaticJsonReprocessMongoAdapter lunaticJsonReprocessMongoAdapter;
+
+    @Override
+    public RawResponseReprocessPersistencePort resolve(RawDataModelType rawDataModelType) {
+        return switch (rawDataModelType) {
+            case FILIERE -> rawResponseReprocessMongoAdapter;
+            case LEGACY ->  lunaticJsonReprocessMongoAdapter;
+        };
+    }
+
+}

--- a/src/test/java/cucumber/functional_tests/RawDataDefinitions.java
+++ b/src/test/java/cucumber/functional_tests/RawDataDefinitions.java
@@ -23,12 +23,7 @@ import fr.insee.genesis.exceptions.GenesisError;
 import fr.insee.genesis.exceptions.GenesisException;
 import fr.insee.genesis.infrastructure.repository.RawResponseInputRepository;
 import fr.insee.genesis.infrastructure.utils.FileUtils;
-import fr.insee.genesis.stubs.ConfigStub;
-import fr.insee.genesis.stubs.DataProcessingContextPersistancePortStub;
-import fr.insee.genesis.stubs.LunaticJsonRawDataPersistanceStub;
-import fr.insee.genesis.stubs.QuestionnaireMetadataPersistencePortStub;
-import fr.insee.genesis.stubs.SurveyUnitPersistencePortStub;
-import fr.insee.genesis.stubs.SurveyUnitQualityToolPerretAdapterStub;
+import fr.insee.genesis.stubs.*;
 import fr.insee.modelefiliere.RawResponseDto;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
@@ -41,12 +36,7 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.io.IOException;
@@ -57,7 +47,6 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -127,11 +116,6 @@ public class RawDataDefinitions {
 
         @Override
         public DataProcessResult processRawResponses(String collectionInstrumentId) throws GenesisException {
-            return null;
-        }
-
-        @Override
-        public DataProcessResult reprocessRawResponses(String collectionInstrumentId, LocalDateTime sinceDate, LocalDateTime endDate) throws GenesisException {
             return null;
         }
 

--- a/src/test/java/fr/insee/genesis/controller/rest/responses/RawResponseControllerTest.java
+++ b/src/test/java/fr/insee/genesis/controller/rest/responses/RawResponseControllerTest.java
@@ -26,13 +26,7 @@ import fr.insee.genesis.infrastructure.document.rawdata.RawResponseDocument;
 import fr.insee.genesis.infrastructure.mappers.DataProcessingContextMapper;
 import fr.insee.genesis.infrastructure.repository.RawResponseInputRepository;
 import fr.insee.genesis.infrastructure.utils.FileUtils;
-import fr.insee.genesis.stubs.ConfigStub;
-import fr.insee.genesis.stubs.DataProcessingContextPersistancePortStub;
-import fr.insee.genesis.stubs.LunaticJsonRawDataPersistanceStub;
-import fr.insee.genesis.stubs.QuestionnaireMetadataPersistencePortStub;
-import fr.insee.genesis.stubs.RawResponseDataPersistanceStub;
-import fr.insee.genesis.stubs.SurveyUnitPersistencePortStub;
-import fr.insee.genesis.stubs.SurveyUnitQualityToolPerretAdapterStub;
+import fr.insee.genesis.stubs.*;
 import fr.insee.modelefiliere.RawResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
@@ -103,11 +97,6 @@ class RawResponseControllerTest {
 
         @Override
         public DataProcessResult processRawResponses(String collectionInstrumentId) throws GenesisException {
-            return null;
-        }
-
-        @Override
-        public DataProcessResult reprocessRawResponses(String collectionInstrumentId, LocalDateTime sinceDate, LocalDateTime endDate) throws GenesisException {
             return null;
         }
 

--- a/src/test/java/fr/insee/genesis/domain/service/rawdata/LunaticJsonRawDataServiceTest.java
+++ b/src/test/java/fr/insee/genesis/domain/service/rawdata/LunaticJsonRawDataServiceTest.java
@@ -15,16 +15,10 @@ import fr.insee.genesis.domain.service.metadata.QuestionnaireMetadataService;
 import fr.insee.genesis.domain.service.surveyunit.SurveyUnitQualityService;
 import fr.insee.genesis.domain.service.surveyunit.SurveyUnitService;
 import fr.insee.genesis.domain.utils.JsonUtils;
-import fr.insee.genesis.exceptions.GenesisException;
 import fr.insee.genesis.infrastructure.mappers.DataProcessingContextMapper;
 import fr.insee.genesis.infrastructure.mappers.LunaticJsonRawDataDocumentMapper;
 import fr.insee.genesis.infrastructure.utils.FileUtils;
-import fr.insee.genesis.stubs.ConfigStub;
-import fr.insee.genesis.stubs.DataProcessingContextPersistancePortStub;
-import fr.insee.genesis.stubs.LunaticJsonRawDataPersistanceStub;
-import fr.insee.genesis.stubs.QuestionnaireMetadataPersistencePortStub;
-import fr.insee.genesis.stubs.SurveyUnitPersistencePortStub;
-import fr.insee.genesis.stubs.SurveyUnitQualityToolPerretAdapterStub;
+import fr.insee.genesis.stubs.*;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -692,47 +686,6 @@ class LunaticJsonRawDataServiceTest {
         Object doubleObject = 101010101010.111d;
 
         Assertions.assertThat(getValueString(doubleObject)).isEqualTo("101010101010.111");
-    }
-
-    @Test
-    void reprocessRawData_should_return_empty_result_when_no_processed_interrogation_ids_found() throws Exception {
-        // GIVEN
-        lunaticJsonRawDataPersistanceStub.getMongoStub().clear();
-        surveyUnitPersistencePortStub.getMongoStub().clear();
-
-        String questionnaireId = "TESTIDQUEST";
-
-        // WHEN
-        DataProcessResult result = lunaticJsonRawDataService.reprocessRawData(questionnaireId, null, null);
-
-        // THEN
-        Assertions.assertThat(result).isNotNull();
-        Assertions.assertThat(result.dataCount()).isZero();
-        Assertions.assertThat(result.formattedDataCount()).isZero();
-        Assertions.assertThat(result.errors()).isEmpty();
-    }
-
-    @Test
-    void reprocessRawData_should_throw_when_endDate_is_provided_without_sinceDate() {
-        String questionnaireId = "TESTIDQUEST";
-        LocalDateTime endDate = LocalDateTime.now();
-
-        Assertions.assertThatThrownBy(() ->
-                        lunaticJsonRawDataService.reprocessRawData(questionnaireId, null, endDate))
-                .isInstanceOf(GenesisException.class)
-                .hasMessage("endDate cannot be provided without sinceDate");
-    }
-
-    @Test
-    void reprocessRawData_should_throw_when_endDate_is_before_sinceDate() {
-        String questionnaireId = "TESTIDQUEST";
-        LocalDateTime sinceDate = LocalDateTime.of(2024, 1, 10, 10, 0);
-        LocalDateTime endDate = LocalDateTime.of(2024, 1, 9, 10, 0);
-
-        Assertions.assertThatThrownBy(() ->
-                        lunaticJsonRawDataService.reprocessRawData(questionnaireId, sinceDate, endDate))
-                .isInstanceOf(GenesisException.class)
-                .hasMessage("endDate must be after or equal to sinceDate");
     }
 
 }

--- a/src/test/java/fr/insee/genesis/domain/service/rawdata/LunaticRawDataReprocessTest.java
+++ b/src/test/java/fr/insee/genesis/domain/service/rawdata/LunaticRawDataReprocessTest.java
@@ -1,0 +1,69 @@
+package fr.insee.genesis.domain.service.rawdata;
+
+import fr.insee.genesis.domain.model.surveyunit.rawdata.DataProcessResult;
+import fr.insee.genesis.domain.model.surveyunit.rawdata.RawDataModelType;
+import fr.insee.genesis.exceptions.InvalidDateIntervalException;
+import fr.insee.genesis.stubs.LunaticJsonRawDataServiceStub;
+import fr.insee.genesis.stubs.RawResponseReprocessPersistenceRouterStub;
+import fr.insee.genesis.stubs.SurveyUnitPersistencePortStub;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+class LunaticRawDataReprocessTest {
+
+    private ReprocessRawResponseService reprocessRawResponseService;
+
+    @BeforeEach
+    void freshStart() {
+        reprocessRawResponseService = new ReprocessRawResponseService(
+            new SurveyUnitPersistencePortStub(),
+            null,
+            new LunaticJsonRawDataServiceStub(),
+            new RawResponseReprocessPersistenceRouterStub());
+    }
+
+    @Test
+    void reprocessRawData_should_return_empty_result_when_no_processed_interrogation_ids_found() throws Exception {
+        // GIVEN
+        String questionnaireId = "TESTIDQUEST";
+
+        // WHEN
+        DataProcessResult result = reprocessRawResponseService.reprocessRawResponses(
+                RawDataModelType.LEGACY, questionnaireId, null, null);
+
+        // THEN
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result.dataCount()).isZero();
+        Assertions.assertThat(result.formattedDataCount()).isZero();
+        Assertions.assertThat(result.errors()).isEmpty();
+    }
+
+    @Test
+    void reprocessRawData_should_throw_when_endDate_is_provided_without_sinceDate() {
+        String questionnaireId = "TESTIDQUEST";
+        LocalDateTime endDate = LocalDateTime.now();
+
+        Assertions.assertThatThrownBy(() ->
+                        reprocessRawResponseService.reprocessRawResponses(
+                                RawDataModelType.LEGACY, questionnaireId, null, endDate))
+                .isInstanceOf(InvalidDateIntervalException.class)
+                .hasMessage("'endDate' cannot be provided without 'sinceDate'.");
+    }
+
+    @Test
+    void reprocessRawData_should_throw_when_endDate_is_before_sinceDate() {
+        String questionnaireId = "TESTIDQUEST";
+        LocalDateTime sinceDate = LocalDateTime.of(2024, 1, 10, 10, 0);
+        LocalDateTime endDate = LocalDateTime.of(2024, 1, 9, 10, 0);
+
+        Assertions.assertThatThrownBy(() ->
+                reprocessRawResponseService.reprocessRawResponses(
+                        RawDataModelType.LEGACY, questionnaireId, sinceDate, endDate))
+                .isInstanceOf(InvalidDateIntervalException.class)
+                .hasMessage("'endDate' value cannot be before 'sinceDate'.");
+    }
+
+}

--- a/src/test/java/fr/insee/genesis/stubs/LunaticJsonRawDataPersistanceStub.java
+++ b/src/test/java/fr/insee/genesis/stubs/LunaticJsonRawDataPersistanceStub.java
@@ -125,31 +125,6 @@ public class LunaticJsonRawDataPersistanceStub implements LunaticJsonRawDataPers
     }
 
     @Override
-    public void resetProcessDates(String questionnaireId, Set<String> interrogationIds) {
-        for (int i = 0; i < mongoStub.size(); i++) {
-            LunaticJsonRawDataDocument document = mongoStub.get(i);
-
-            if (document.questionnaireId().equals(questionnaireId)
-                    && interrogationIds.contains(document.interrogationId())) {
-
-                LunaticJsonRawDataDocument newDocument = LunaticJsonRawDataDocument.builder()
-                        .id(document.id())
-                        .campaignId(document.campaignId())
-                        .questionnaireId(document.questionnaireId())
-                        .interrogationId(document.interrogationId())
-                        .idUE(document.idUE())
-                        .mode(document.mode())
-                        .data(document.data())
-                        .recordDate(document.recordDate())
-                        .processDate(null)
-                        .build();
-
-                mongoStub.set(i, newDocument);
-            }
-        }
-    }
-
-    @Override
     public Set<String> findDistinctQuestionnaireIds() {
         Set<String> questionnaireIds = new HashSet<>();
         for(LunaticJsonRawDataDocument rawDataDoc : mongoStub){
@@ -268,13 +243,4 @@ public class LunaticJsonRawDataPersistanceStub implements LunaticJsonRawDataPers
         return 0;
     }
 
-    @Override
-    public Set<String> findProcessedInterrogationIdsByQuestionnaireId(String questionnaireId) {
-        return Set.of();
-    }
-
-    @Override
-    public Set<String> findProcessedInterrogationIdsByQuestionnaireIdAndRecordDateBetween(String questionnaireId, LocalDateTime sinceDate, LocalDateTime endDate) {
-        return Set.of();
-    }
 }

--- a/src/test/java/fr/insee/genesis/stubs/LunaticJsonRawDataServiceStub.java
+++ b/src/test/java/fr/insee/genesis/stubs/LunaticJsonRawDataServiceStub.java
@@ -1,0 +1,101 @@
+package fr.insee.genesis.stubs;
+
+import fr.insee.bpm.metadata.model.VariablesMap;
+import fr.insee.genesis.controller.dto.rawdata.LunaticJsonRawDataUnprocessedDto;
+import fr.insee.genesis.domain.model.surveyunit.Mode;
+import fr.insee.genesis.domain.model.surveyunit.SurveyUnitModel;
+import fr.insee.genesis.domain.model.surveyunit.rawdata.DataProcessResult;
+import fr.insee.genesis.domain.model.surveyunit.rawdata.LunaticJsonRawDataModel;
+import fr.insee.genesis.domain.ports.api.LunaticJsonRawDataApiPort;
+import fr.insee.genesis.exceptions.GenesisError;
+import fr.insee.genesis.exceptions.GenesisException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class LunaticJsonRawDataServiceStub implements LunaticJsonRawDataApiPort {
+    @Override
+    public void save(LunaticJsonRawDataModel rawData) {
+
+    }
+
+    @Override
+    public List<LunaticJsonRawDataModel> getRawDataByQuestionnaireId(String questionnaireId, Mode mode, List<String> interrogationIdList) {
+        return List.of();
+    }
+
+    @Override
+    public List<SurveyUnitModel> convertRawData(List<LunaticJsonRawDataModel> rawData, VariablesMap variablesMap) {
+        return List.of();
+    }
+
+    @Override
+    public List<LunaticJsonRawDataUnprocessedDto> getUnprocessedDataIds() {
+        return List.of();
+    }
+
+    @Override
+    public Set<String> getUnprocessedDataQuestionnaireIds() {
+        return Set.of();
+    }
+
+    @Override
+    public void updateProcessDates(List<SurveyUnitModel> surveyUnitModels) {
+
+    }
+
+    @Override
+    public Set<String> findDistinctQuestionnaireIds() {
+        return Set.of();
+    }
+
+    @Override
+    public long countRawResponsesByQuestionnaireId(String campaignId) {
+        return 0;
+    }
+
+    @Override
+    public long countDistinctInterrogationIdsByQuestionnaireId(String questionnaireId) {
+        return 0;
+    }
+
+    @Override
+    public Page<LunaticJsonRawDataModel> findRawDataByCampaignIdAndDate(String campaignId, Instant startDt, Instant endDt, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public List<LunaticJsonRawDataModel> getRawDataByInterrogationId(String interrogationId) {
+        return List.of();
+    }
+
+    @Override
+    public DataProcessResult processRawData(String campaignName, List<String> interrogationIdList, List<GenesisError> errors) throws GenesisException {
+        return null;
+    }
+
+    @Override
+    public DataProcessResult processRawData(String collectionInstrumentId) throws GenesisException {
+        return null;
+    }
+
+    @Override
+    public Map<String, List<String>> findProcessedIdsgroupedByQuestionnaireSince(LocalDateTime since) {
+        return Map.of();
+    }
+
+    @Override
+    public Page<LunaticJsonRawDataModel> findRawDataByQuestionnaireId(String questionnaireId, Pageable pageable) {
+        return null;
+    }
+
+    @Override
+    public boolean existsByInterrogationId(String interrogationId) {
+        return false;
+    }
+}

--- a/src/test/java/fr/insee/genesis/stubs/LunaticJsonRawDataServiceStub.java
+++ b/src/test/java/fr/insee/genesis/stubs/LunaticJsonRawDataServiceStub.java
@@ -21,7 +21,7 @@ import java.util.Set;
 public class LunaticJsonRawDataServiceStub implements LunaticJsonRawDataApiPort {
     @Override
     public void save(LunaticJsonRawDataModel rawData) {
-
+        // stub, this method unused in tests yet.
     }
 
     @Override
@@ -46,7 +46,7 @@ public class LunaticJsonRawDataServiceStub implements LunaticJsonRawDataApiPort 
 
     @Override
     public void updateProcessDates(List<SurveyUnitModel> surveyUnitModels) {
-
+        // stub, this method unused in tests yet.
     }
 
     @Override

--- a/src/test/java/fr/insee/genesis/stubs/RawResponseDataPersistanceStub.java
+++ b/src/test/java/fr/insee/genesis/stubs/RawResponseDataPersistanceStub.java
@@ -94,22 +94,6 @@ public class RawResponseDataPersistanceStub implements RawResponsePersistencePor
     }
 
     @Override
-    public Set<String> findProcessedInterrogationIdsByCollectionInstrumentId(String collectionInstrumentId) {
-        return Set.of();
-    }
-
-    @Override
-    public Set<String> findProcessedInterrogationIdsByCollectionInstrumentIdAndRecordDateBetween(String collectionInstrumentId, LocalDateTime sinceDate, LocalDateTime endDate) {
-        return Set.of();
-    }
-
-    @Override
-    public void resetProcessDates(String collectionInstrumentId, Set<String> interrogationIds) {
-        // do nothing
-        return;
-    }
-
-    @Override
     public long countByCollectionInstrumentId(String collectionInstrumentId) {
         return 0;
     }

--- a/src/test/java/fr/insee/genesis/stubs/RawResponseReprocessPersistenceRouterStub.java
+++ b/src/test/java/fr/insee/genesis/stubs/RawResponseReprocessPersistenceRouterStub.java
@@ -1,0 +1,14 @@
+package fr.insee.genesis.stubs;
+
+import fr.insee.genesis.domain.model.surveyunit.rawdata.RawDataModelType;
+import fr.insee.genesis.domain.ports.spi.RawResponseReprocessPersistencePort;
+import fr.insee.genesis.domain.ports.spi.RawResponseReprocessPersistenceRouter;
+
+public class RawResponseReprocessPersistenceRouterStub implements RawResponseReprocessPersistenceRouter {
+
+    @Override
+    public RawResponseReprocessPersistencePort resolve(RawDataModelType rawDataModelType) {
+        return new RawResponseReprocessPersistenceStub();
+    }
+
+}

--- a/src/test/java/fr/insee/genesis/stubs/RawResponseReprocessPersistenceStub.java
+++ b/src/test/java/fr/insee/genesis/stubs/RawResponseReprocessPersistenceStub.java
@@ -1,0 +1,50 @@
+package fr.insee.genesis.stubs;
+
+import fr.insee.genesis.domain.ports.spi.RawResponseReprocessPersistencePort;
+import fr.insee.genesis.infrastructure.document.rawdata.LunaticJsonRawDataDocument;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class RawResponseReprocessPersistenceStub implements RawResponseReprocessPersistencePort {
+
+    List<LunaticJsonRawDataDocument> mongoStub = new ArrayList<>();
+
+    @Override
+    public Set<String> findProcessedInterrogationIdsByCollectionInstrumentId(String questionnaireId) {
+        return Set.of();
+    }
+
+    @Override
+    public Set<String> findProcessedInterrogationIdsByCollectionInstrumentIdAndRecordDateBetween(String questionnaireId, LocalDateTime sinceDate, LocalDateTime endDate) {
+        return Set.of();
+    }
+
+    @Override
+    public void resetProcessDates(String questionnaireId, Set<String> interrogationIds) {
+        for (int i = 0; i < mongoStub.size(); i++) {
+            LunaticJsonRawDataDocument document = mongoStub.get(i);
+
+            if (document.questionnaireId().equals(questionnaireId)
+                    && interrogationIds.contains(document.interrogationId())) {
+
+                LunaticJsonRawDataDocument newDocument = LunaticJsonRawDataDocument.builder()
+                        .id(document.id())
+                        .campaignId(document.campaignId())
+                        .questionnaireId(document.questionnaireId())
+                        .interrogationId(document.interrogationId())
+                        .idUE(document.idUE())
+                        .mode(document.mode())
+                        .data(document.data())
+                        .recordDate(document.recordDate())
+                        .processDate(null)
+                        .build();
+
+                mongoStub.set(i, newDocument);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
@Hajarel-moukh j'ai d'abord voulu réduire la complexité qu'on avait dans le reprocessing (NB : le plugin `CodeMetrics` d'intellij est pas mal pour ça, ça invite à corriger tout de suite les parties du code qui deviennent complexes) ; en tirant le fil j'ai été un peu plus loin, mais j'ai laissé la logique telle qu'elle.

J'aurais pu commit direct sur ta branche mais je fais une PR pour que tu puisses revoir facilement le git diff.

Refacto : 

- Principalement : j'ai isolé la logique de reprocessing à part (dans l'idée une classe = un but).
- ⚠️ en l'état le reprocessing pour les données brutes Lunatic utilise une fonction dépréciée.
- ❓ J'ai l'impression qu'on ne gère pas le cas où le DataProcessResult contient des erreurs dans le reprocessing.
- Je me suis un peu embêté pour pas dupliquer la logique du reprocessing dans le domain.
- Controller advice / exception handlers : j'ai refacto finalement, mais seulement sur le nouveau code, pour pas ajouter de nouvelle dette technique.
  - Au passage j'ai fait ça pour respecter la RFC 9457 (merci @davdarras)

Quelques remarques plus générales sur des choses que j'ai vues dans la base de code : 

- ⚠️ on ne veut pas de logique métier dans les controllers / pas de notions techniques (exemple : code retour http) dans le domaine
  - NB : On pourrait déplacer les exceptions métier dans le domaine.
- J'ai viré un "ApiPort" qui n'était pas utilisé dans des couches supérieures (le "PersistencePort" suffit)
  - 👀 y a peut-être pas mal de méthode d'api ports (ports in du domain) qui ne servent pas et qu'on pourrait virer
